### PR TITLE
- use mempool to re-fillup FQ for robust packet recv

### DIFF
--- a/result/client.txt
+++ b/result/client.txt
@@ -1,3 +1,4 @@
+Attaching to afxdptest_client_1
 client_1   | Actual changes:
 client_1   | tx-checksumming: off
 client_1   |    tx-checksum-ip-generic: off
@@ -11,92 +12,108 @@ client_1   | 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
 client_1   |     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 client_1   | 2: sit0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default qlen 1000
 client_1   |     link/sit 0.0.0.0 brd 0.0.0.0
-client_1   | 31: eth0@if32: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
+client_1   | 42: eth0@if43: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
 client_1   |     link/ether 02:42:ac:10:ef:0b brd ff:ff:ff:ff:ff:ff link-netnsid 0
+client_1   | setup static ARP tables for test
+client_1   | sleep 30s for waiting other test containers ready
 client_1   | ping test to 172.16.239.14
 client_1   | PING 172.16.239.14 (172.16.239.14): 56 data bytes
-client_1   | 64 bytes from 172.16.239.14: seq=0 ttl=64 time=0.100 ms
-client_1   | 64 bytes from 172.16.239.14: seq=1 ttl=64 time=0.171 ms
-client_1   | 64 bytes from 172.16.239.14: seq=2 ttl=64 time=0.077 ms
-client_1   | 64 bytes from 172.16.239.14: seq=3 ttl=64 time=0.174 ms
-client_1   | 64 bytes from 172.16.239.14: seq=4 ttl=64 time=0.078 ms
-client_1   | 64 bytes from 172.16.239.14: seq=5 ttl=64 time=0.075 ms
-client_1   | 64 bytes from 172.16.239.14: seq=6 ttl=64 time=0.082 ms
-client_1   | 64 bytes from 172.16.239.14: seq=7 ttl=64 time=0.081 ms
-client_1   | 64 bytes from 172.16.239.14: seq=8 ttl=64 time=0.077 ms
-client_1   | 64 bytes from 172.16.239.14: seq=9 ttl=64 time=0.077 ms
-client_1   | 64 bytes from 172.16.239.14: seq=10 ttl=64 time=0.076 ms
-client_1   | 64 bytes from 172.16.239.14: seq=11 ttl=64 time=0.231 ms
-client_1   | 64 bytes from 172.16.239.14: seq=12 ttl=64 time=0.076 ms
-client_1   | 64 bytes from 172.16.239.14: seq=13 ttl=64 time=0.134 ms
-client_1   | 64 bytes from 172.16.239.14: seq=14 ttl=64 time=0.083 ms
-client_1   | 64 bytes from 172.16.239.14: seq=15 ttl=64 time=0.077 ms
+client_1   | 64 bytes from 172.16.239.14: seq=0 ttl=64 time=0.113 ms
+client_1   | 64 bytes from 172.16.239.14: seq=1 ttl=64 time=0.213 ms
+client_1   | 64 bytes from 172.16.239.14: seq=2 ttl=64 time=0.277 ms
+client_1   | 64 bytes from 172.16.239.14: seq=3 ttl=64 time=0.107 ms
+client_1   | 64 bytes from 172.16.239.14: seq=4 ttl=64 time=0.107 ms
+client_1   | 64 bytes from 172.16.239.14: seq=5 ttl=64 time=0.099 ms
+client_1   | 64 bytes from 172.16.239.14: seq=6 ttl=64 time=0.163 ms
+client_1   | 64 bytes from 172.16.239.14: seq=7 ttl=64 time=0.113 ms
+client_1   | 64 bytes from 172.16.239.14: seq=8 ttl=64 time=0.092 ms
+client_1   | 64 bytes from 172.16.239.14: seq=9 ttl=64 time=0.092 ms
+client_1   | 64 bytes from 172.16.239.14: seq=10 ttl=64 time=0.097 ms
+client_1   | 64 bytes from 172.16.239.14: seq=11 ttl=64 time=0.098 ms
+client_1   | 64 bytes from 172.16.239.14: seq=12 ttl=64 time=0.203 ms
+client_1   | 64 bytes from 172.16.239.14: seq=13 ttl=64 time=0.094 ms
+client_1   | 64 bytes from 172.16.239.14: seq=14 ttl=64 time=0.187 ms
+client_1   | 64 bytes from 172.16.239.14: seq=15 ttl=64 time=0.084 ms
 client_1   |
 client_1   | --- 172.16.239.14 ping statistics ---
 client_1   | 16 packets transmitted, 16 packets received, 0% packet loss
-client_1   | round-trip min/avg/max = 0.075/0.104/0.231 ms
+client_1   | round-trip min/avg/max = 0.084/0.133/0.277 ms
 client_1   | ping test to 172.16.239.12
 client_1   | PING 172.16.239.12 (172.16.239.12): 56 data bytes
+client_1   | 64 bytes from 172.16.239.12: seq=1 ttl=64 time=1.091 ms
+client_1   | 64 bytes from 172.16.239.12: seq=2 ttl=64 time=90.416 ms
+client_1   | 64 bytes from 172.16.239.12: seq=3 ttl=64 time=1.140 ms
+client_1   | 64 bytes from 172.16.239.12: seq=4 ttl=64 time=0.618 ms
+client_1   | 64 bytes from 172.16.239.12: seq=5 ttl=64 time=0.946 ms
+client_1   | 64 bytes from 172.16.239.12: seq=6 ttl=64 time=1.130 ms
+client_1   | 64 bytes from 172.16.239.12: seq=7 ttl=64 time=0.360 ms
+client_1   | 64 bytes from 172.16.239.12: seq=8 ttl=64 time=1.106 ms
+client_1   | 64 bytes from 172.16.239.12: seq=9 ttl=64 time=0.617 ms
+client_1   | 64 bytes from 172.16.239.12: seq=10 ttl=64 time=0.657 ms
+client_1   | 64 bytes from 172.16.239.12: seq=11 ttl=64 time=0.314 ms
+client_1   | 64 bytes from 172.16.239.12: seq=12 ttl=64 time=1.785 ms
+client_1   | 64 bytes from 172.16.239.12: seq=13 ttl=64 time=0.605 ms
+client_1   | 64 bytes from 172.16.239.12: seq=14 ttl=64 time=0.413 ms
+client_1   | 64 bytes from 172.16.239.12: seq=15 ttl=64 time=2.161 ms
 client_1   |
 client_1   | --- 172.16.239.12 ping statistics ---
-client_1   | 16 packets transmitted, 0 packets received, 100% packet loss
+client_1   | 16 packets transmitted, 15 packets received, 6% packet loss
+client_1   | round-trip min/avg/max = 0.314/6.890/90.416 ms
 client_1   | curl test to 172.16.239.14
-client_1   | * Expire in 0 ms for 6 (transfer 0x55f9967957a0)
-client_1   | * Expire in 60000 ms for 8 (transfer 0x55f9967957a0)
-client_1   | * Expire in 10000 ms for 2 (transfer 0x55f9967957a0)
+client_1   | * Expire in 0 ms for 6 (transfer 0x562571534680)
+client_1   | * Expire in 60000 ms for 8 (transfer 0x562571534680)
+client_1   | * Expire in 10000 ms for 2 (transfer 0x562571534680)
 client_1   | *   Trying 172.16.239.14...
 client_1   | * TCP_NODELAY set
-client_1   | * Expire in 200 ms for 4 (transfer 0x55f9967957a0)
+client_1   | * Expire in 200 ms for 4 (transfer 0x562571534680)
+client_1   | <html>
+client_1   |   <head>
 client_1   |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+client_1   |   </head>
 client_1   |                                  Dload  Upload   Total   Spent    Left  Speed
-0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to 172.16.239.14 (172.16.239.14) port 80 (#0)
+client_1   |   <body>
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to 172.16.239.14 (172.16.239.14) port 80 (#0)
+client_1   |   <h1>Hello</h1>
 client_1   | > GET / HTTP/1.1
+client_1   |   </body>
 client_1   | > Host: 172.16.239.14
+client_1   | </html>
 client_1   | > User-Agent: curl/7.64.0
+client_1   | curl test to 172.16.239.12
 client_1   | > Accept: */*
 client_1   | >
 client_1   | * HTTP 1.0, assume close after body
 client_1   | < HTTP/1.0 200 OK
 client_1   | < Server: SimpleHTTP/0.6 Python/2.7.16
-client_1   | < Date: Wed, 18 Sep 2019 04:07:59 GMT
+client_1   | < Date: Tue, 12 Nov 2019 05:24:11 GMT
 client_1   | < Content-type: text/html
 client_1   | < Content-Length: 70
 client_1   | < Last-Modified: Tue, 17 Sep 2019 02:09:03 GMT
 client_1   | <
 client_1   | { [70 bytes data]
-100    70  100    70    0     0   3333      0 --:--:-- --:--:-- --:--:--  4666
+100    70  100    70    0     0   2413      0 --:--:-- --:--:-- --:--:--  4666
 client_1   | * Closing connection 0
-client_1   | <html>
-client_1   |   <head>
-client_1   |   </head>
-client_1   |   <body>
-client_1   |   <h1>Hello</h1>
-client_1   |   </body>
-client_1   | </html>
-client_1   | curl test to 172.16.239.12
-client_1   | * Expire in 0 ms for 6 (transfer 0x55f45e7877a0)
-client_1   | * Expire in 60000 ms for 8 (transfer 0x55f45e7877a0)
-client_1   | * Expire in 10000 ms for 2 (transfer 0x55f45e7877a0)
+client_1   | * Expire in 0 ms for 6 (transfer 0x561c922c1680)
+client_1   | * Expire in 60000 ms for 8 (transfer 0x561c922c1680)
+client_1   | * Expire in 10000 ms for 2 (transfer 0x561c922c1680)
 client_1   | *   Trying 172.16.239.12...
 client_1   | * TCP_NODELAY set
-client_1   | * Expire in 200 ms for 4 (transfer 0x55f45e7877a0)
+client_1   | * Expire in 200 ms for 4 (transfer 0x561c922c1680)
 client_1   |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
 client_1   |                                  Dload  Upload   Total   Spent    Left  Speed
-0     0    0     0    0     0      0      0 --:--:--  0:00:09 --:--:--     0* Connection timed out after 10001 milliseconds
-0     0    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
+  0     0    0     0    0     0      0      0 --:--:--  0:00:09 --:--:--     0* Connection timed out after 10001 milliseconds
+  0     0    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
 client_1   | * Closing connection 0
 client_1   | curl: (28) Connection timed out after 10001 milliseconds
 client_1   | iperf test to 172.16.239.14
 client_1   | Connecting to host 172.16.239.14, port 3091
-client_1   | [  5] local 172.16.239.13 port 35316 connected to 172.16.239.14 port 3091
+client_1   | [  5] local 172.16.239.13 port 33092 connected to 172.16.239.14 port 3091
 client_1   | [ ID] Interval           Transfer     Bitrate         Retr  Cwnd
-client_1   | [  5]   0.00-0.35   sec  30.5 MBytes   735 Mbits/sec    0    393 KBytes
+client_1   | [  5]   0.00-0.18   sec  30.0 MBytes  1.38 Gbits/sec    0    133 KBytes
 client_1   | - - - - - - - - - - - - - - - - - - - - - - - - -
 client_1   | [ ID] Interval           Transfer     Bitrate         Retr
-client_1   | [  5]   0.00-0.35   sec  30.5 MBytes   735 Mbits/sec    0             sender
-client_1   | [  5]   0.00-0.35   sec  27.0 MBytes   647 Mbits/sec                  receiver
+client_1   | [  5]   0.00-0.18   sec  30.0 MBytes  1.38 Gbits/sec    0             sender
+client_1   | [  5]   0.00-0.18   sec  30.0 MBytes  1.36 Gbits/sec                  receiver
 client_1   |
 client_1   | iperf Done.
 client_1   | iperf test to 172.16.239.12
-client_1   | iperf3: error - unable to connect to server: Operation timed out
-afxdptest_client_1 exited with code 1

--- a/result/router.txt
+++ b/result/router.txt
@@ -7,81 +7,86 @@ router_1   |    tx-tcp-segmentation: off [requested on]
 router_1   |    tx-tcp-ecn-segmentation: off [requested on]
 router_1   |    tx-tcp-mangleid-segmentation: off [requested on]
 router_1   |    tx-tcp6-segmentation: off [requested on]
-router_1   | 2019/09/18 04:06:48 ===== Example setup =====
-router_1   | 2019/09/18 04:06:48 ===== Example start =====
-router_1   | 2019/09/18 04:06:48 ======= Start running driver =======
-router_1   | 2019/09/18 04:06:48 Libbpf runner worker starting
-router_1   | 2019/09/18 04:06:48 Libbpf Run called
-router_1   | 2019/09/18 04:07:40 libbpf fetch 2 packets
-router_1   | 2019/09/18 04:07:40 Packet type IPv6 length 90
-router_1   | 2019/09/18 04:07:40 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:07:40 Packet type IPv6 length 86
-router_1   | 2019/09/18 04:07:40 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:04 libbpf fetch 15 packets
-router_1   | 2019/09/18 04:08:04 Packet type IPv6 length 90
-router_1   | 2019/09/18 04:08:04 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:04 Packet type IPv6 length 70
-router_1   | 2019/09/18 04:08:04 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:04 Packet type IPv6 length 90
-router_1   | 2019/09/18 04:08:04 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:04 Packet type IPv6 length 70
-router_1   | 2019/09/18 04:08:04 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:04 Packet type IPv6 length 70
-router_1   | 2019/09/18 04:08:04 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:04 Packet type IPv6 length 70
-router_1   | 2019/09/18 04:08:04 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:04 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:04 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:04 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:04 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:04 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:04 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:04 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:04 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:04 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:04 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 libbpf fetch 16 packets
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv6 length 70
-router_1   | 2019/09/18 04:08:17 Libbpf based AF_XDP drops packet due to error: ipv6 not support
-router_1   | 2019/09/18 04:08:17 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:17 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:17 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:17 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:17 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:17 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:17 libbpf fetch 6 packets
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:17 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 libbpf fetch 16 packets
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type ARP length 42
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 libbpf fetch 2 packets
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
-router_1   | 2019/09/18 04:08:43 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:10 ===== Example setup =====
+router_1   | 2019/11/12 05:23:10 ===== Example start =====
+router_1   | 2019/11/12 05:23:10 ======= Start running driver =======
+router_1   | 2019/11/12 05:23:10 Libbpf runner worker starting
+router_1   | 2019/11/12 05:23:10 Libbpf Run called
+router_1   | 2019/11/12 05:23:11 Packet type IPv6 length 86
+router_1   | 2019/11/12 05:23:11 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:11 Packet type IPv6 length 90
+router_1   | 2019/11/12 05:23:11 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:12 Packet type IPv6 length 90
+router_1   | 2019/11/12 05:23:12 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:12 Packet type IPv6 length 70
+router_1   | 2019/11/12 05:23:12 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:13 Packet type IPv6 length 90
+router_1   | 2019/11/12 05:23:13 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:16 Packet type IPv6 length 70
+router_1   | 2019/11/12 05:23:16 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:25 Packet type IPv6 length 70
+router_1   | 2019/11/12 05:23:25 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:41 Packet type IPv6 length 70
+router_1   | 2019/11/12 05:23:41 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:23:55 Packet type ARP length 42
+router_1   | 2019/11/12 05:23:56 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:56 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:56 Packet type ARP length 42
+router_1   | 2019/11/12 05:23:57 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:57 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:57 Packet type ARP length 42
+router_1   | 2019/11/12 05:23:58 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:58 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:59 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:23:59 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:00 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:00 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:01 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:01 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:02 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:02 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:03 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:03 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:04 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:04 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:05 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:05 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:06 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:06 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:07 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:07 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:08 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:08 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:09 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:09 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:10 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:10 Packet type IPv4 length 98
+router_1   | 2019/11/12 05:24:11 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:12 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:13 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:14 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:15 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:16 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:18 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:19 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:20 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:20 Packet type IPv6 length 70
+router_1   | 2019/11/12 05:24:20 Libbpf based AF_XDP drops packet due to error: ipv6 not support
+router_1   | 2019/11/12 05:24:21 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:22 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:23 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:24 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:25 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:26 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:28 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:29 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:30 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:36 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:37 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:38 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:53 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:54 Packet type ARP length 42
+router_1   | 2019/11/12 05:24:55 Packet type ARP length 42
+router_1   | 2019/11/12 05:25:25 Packet type ARP length 42
+router_1   | 2019/11/12 05:25:26 Packet type ARP length 42
+router_1   | 2019/11/12 05:25:27 Packet type ARP length 42

--- a/result/service.txt
+++ b/result/service.txt
@@ -11,7 +11,7 @@ service_1  | 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
 service_1  |     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 service_1  | 2: sit0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default qlen 1000
 service_1  |     link/sit 0.0.0.0 brd 0.0.0.0
-service_1  | 35: eth0@if36: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
+service_1  | 38: eth0@if39: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
 service_1  |     link/ether 02:42:ac:10:ef:0a brd ff:ff:ff:ff:ff:ff link-netnsid 0
 service_1  | Serving HTTP on 0.0.0.0 port 80 ...
-service_1  | 172.16.239.13 - - [18/Sep/2019 04:07:59] "GET / HTTP/1.1" 200 -
+service_1  | 172.16.239.13 - - [12/Nov/2019 05:24:11] "GET / HTTP/1.1" 200 -

--- a/src/router/driver/libbpf/README.md
+++ b/src/router/driver/libbpf/README.md
@@ -1,0 +1,3 @@
+# Memory model
+
+

--- a/src/router/driver/libbpf/errno_linux.go
+++ b/src/router/driver/libbpf/errno_linux.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	ErrInvalidLibbpf = errors.New("invalid libbpf init")
 	ErrAlreadyInited = errors.New("already been inited")
 	ErrAllocXskPtr   = errors.New("allocate xsk pointer")
 	ErrAllocUmemCfg  = errors.New("allocate umem config")
@@ -18,12 +19,15 @@ var (
 	ErrGetNicIdx     = errors.New("get nic index")
 	ErrLinkBpfToXsk  = errors.New("link bpf to xsk")
 	ErrReserveFQBuf  = errors.New("reserve FQ buffer")
+	ErrAllocMempool  = errors.New("allocate mempool failed")
+	ErrAllocInqueue  = errors.New("allocate in-queue failed")
+	ErrAllocMemBufs  = errors.New("allocate mem-bufs failed")
 )
 
-var initErrors map[int]error
+var afxdpErrors map[int]error
 
 func init() {
-	initErrors = map[int]error{
+	afxdpErrors = map[int]error{
 		int(C.E_ALREADY_INITED):  ErrAlreadyInited,
 		int(C.E_ALLOC_XSK_PTR):   ErrAllocXskPtr,
 		int(C.E_ALLOC_UMEM_CFG):  ErrAllocUmemCfg,
@@ -32,5 +36,8 @@ func init() {
 		int(C.E_GET_NIC_IDX):     ErrGetNicIdx,
 		int(C.E_LINK_BPF_TO_XSK): ErrLinkBpfToXsk,
 		int(C.E_RESERVE_FQ_BUF):  ErrReserveFQBuf,
+		int(C.E_ALLOC_MEMPOOL):   ErrAllocMempool,
+		int(C.E_ALLOC_INQUEUE):   ErrAllocInqueue,
+		int(C.E_ALLOC_MEM_BUFS):  ErrAllocMemBufs,
 	}
 }

--- a/src/router/driver/libbpf/errors.h
+++ b/src/router/driver/libbpf/errors.h
@@ -3,6 +3,8 @@
 #ifndef __GLASNOSTIC_LIBBPF_ERRORS_H__
 #define __GLASNOSTIC_LIBBPF_ERRORS_H__
 
+#include <errno.h>  // for errno reporting
+
 enum init_error {
 	E_ALREADY_INITED  = -1,
 	E_ALLOC_XSK_PTR   = -2,
@@ -11,11 +13,18 @@ enum init_error {
 	E_CREATE_XSK      = -5,
 	E_GET_NIC_IDX     = -6,
 	E_LINK_BPF_TO_XSK = -7,
-	E_RESERVE_FQ_BUF  = -8
+	E_RESERVE_FQ_BUF  = -8,
+	E_ALLOC_MEMPOOL   = -9,
+	E_ALLOC_INQUEUE   = -10,
+	E_ALLOC_MEM_BUFS  = -11
 };
 
-
 // report_errno return last set errno
-char * report_errno();
+char *report_errno();
+
+static inline int ignored(int n)
+{
+	return n == ENOBUFS || n == EAGAIN || n == EBUSY;
+}
 
 #endif // __GLASNOSTIC_LIBBPF_ERRORS_H__

--- a/src/router/driver/libbpf/mempool.c
+++ b/src/router/driver/libbpf/mempool.c
@@ -5,51 +5,43 @@
 
 #include "mempool.h"
 
-static inline void *mem_addr(struct mempool *pool, int idx)
+static inline int in_range(struct mempool *pool, uint64_t addr)
 {
-	return (void*)(uint64_t)(pool->base + idx*pool->room);
-}
-
-static inline int mem_index(struct mempool *pool, void *addr)
-{
-	return ((uint64_t)addr - (uint64_t)pool->base ) / pool->room;
-}
-
-static inline int in_range(struct mempool *pool, void *addr)
-{
-	uint64_t base = (uint64_t)pool->base;
-	uint64_t end = (uint64_t)pool->base + pool->len*pool->room;
-	uint64_t ptr = (uint64_t)addr;
+	uint64_t base = pool->base;
+	uint64_t end = pool->base + pool->len*pool->room;
+	uint64_t ptr = pool->base + addr;
 	return base <= ptr && ptr <= end;
 }
 
-int push(struct mempool *pool, void *addr)
+int push(struct mempool *pool, uint64_t addr)
 {
+	// unlikely
 	if (pool->head == 0 || !in_range(pool, addr)) {
 		// stack is full, can't push anymore elements
-		// or the addr is not in mempool memory area range
+		// or the offset is not in mempool memory area range
 		return -1;
 	}
 
 	pool->head++;
-	pool->addr[pool->head] = mem_index(pool, addr);
+	pool->addr[pool->head] = addr;
 
 	return pool->head;
 }
 
-void *pop(struct mempool *pool)
+// pop should be called after checking there's still element inside mempool
+uint64_t pop(struct mempool *pool)
 {
-	if (pool->head >= pool->len) {
-		// check if stack still has available elements
-		return NULL;
-	}
-	return mem_addr(pool, pool->addr[pool->head++]);
+	// if (pool->head >= pool->len) {
+	// 	// check if stack still has available elements
+	// 	return NULL;
+	// }
+	return pool->addr[pool->head++];
 }
 
-struct mempool *mempool_create(void *base, size_t len, size_t room)
+struct mempool *mempool_create(uint64_t base, uint32_t len, uint32_t room)
 {
 	// create stack indexes
-	int *addr = calloc(len, sizeof(*addr));
+	uint64_t *addr = calloc(len, sizeof(*addr));
 	if (!addr) {
 		goto mem_stack_addr_out;
 	}
@@ -69,13 +61,13 @@ struct mempool *mempool_create(void *base, size_t len, size_t room)
 	pool->len = len;
 
 	// init memstack struct with stack indexes
-	for (int i = 0; i < len; i++) {
-		addr[i] = i;
+	for (uint64_t i = 0; i < len; i++) {
+		addr[i] = i*room;
 	}
-	//   head       len
-	//   |          |
-	//   v          v
-	// [ 0 1 2 .... n-1 ] // n elements
+	//   head                            len
+	//   |                               |
+	//   v                               v
+	// [ (0*room) (1*room) (2*room) .... ((n-1)*room) ] // n elements
 
 	return pool;
 
@@ -87,7 +79,7 @@ mem_stack_addr_out:
 	return NULL;
 }
 
-int allocate(struct mempool *pool, void **bufs, size_t nb_pkts)
+int allocate(struct mempool *pool, uint64_t *bufs, uint32_t nb_pkts)
 {
 	if ((pool->len - pool->head) < nb_pkts) {
 		// not enough buffers in mempool
@@ -101,7 +93,7 @@ int allocate(struct mempool *pool, void **bufs, size_t nb_pkts)
 	return nb_pkts;
 }
 
-void release(struct mempool *pool, void **bufs, size_t nb_pkts)
+void release(struct mempool *pool, uint64_t *bufs, uint32_t nb_pkts)
 {
 	for (int i = 0; i < nb_pkts; i++) {
 		push(pool, bufs[i]);

--- a/src/router/driver/libbpf/mempool.c
+++ b/src/router/driver/libbpf/mempool.c
@@ -22,7 +22,7 @@ int push(struct mempool *pool, uint64_t addr)
 		return -1;
 	}
 
-	pool->head++;
+	pool->head--;
 	pool->addr[pool->head] = addr;
 
 	return pool->head;
@@ -31,10 +31,6 @@ int push(struct mempool *pool, uint64_t addr)
 // pop should be called after checking there's still element inside mempool
 uint64_t pop(struct mempool *pool)
 {
-	// if (pool->head >= pool->len) {
-	// 	// check if stack still has available elements
-	// 	return NULL;
-	// }
 	return pool->addr[pool->head++];
 }
 

--- a/src/router/driver/libbpf/mempool.c
+++ b/src/router/driver/libbpf/mempool.c
@@ -1,0 +1,109 @@
+// +build linux
+
+#include <unistd.h>
+#include <stdint.h>       // for uintptr_t
+
+#include "mempool.h"
+
+static inline void *mem_addr(struct mempool *pool, int idx)
+{
+	return (void*)(uint64_t)(pool->base + idx*pool->room);
+}
+
+static inline int mem_index(struct mempool *pool, void *addr)
+{
+	return ((uint64_t)addr - (uint64_t)pool->base ) / pool->room;
+}
+
+static inline int in_range(struct mempool *pool, void *addr)
+{
+	uint64_t base = (uint64_t)pool->base;
+	uint64_t end = (uint64_t)pool->base + pool->len*pool->room;
+	uint64_t ptr = (uint64_t)addr;
+	return base <= ptr && ptr <= end;
+}
+
+int push(struct mempool *pool, void *addr)
+{
+	if (pool->head == 0 || !in_range(pool, addr)) {
+		// stack is full, can't push anymore elements
+		// or the addr is not in mempool memory area range
+		return -1;
+	}
+
+	pool->head++;
+	pool->addr[pool->head] = mem_index(pool, addr);
+
+	return pool->head;
+}
+
+void *pop(struct mempool *pool)
+{
+	if (pool->head >= pool->len) {
+		// check if stack still has available elements
+		return NULL;
+	}
+	return mem_addr(pool, pool->addr[pool->head++]);
+}
+
+struct mempool *mempool_create(void *base, size_t len, size_t room)
+{
+	// create stack indexes
+	int *addr = calloc(len, sizeof(*addr));
+	if (!addr) {
+		goto mem_stack_addr_out;
+	}
+
+	struct mempool *pool = calloc(1, sizeof(*pool));
+	if (!pool) {
+		goto mem_pool_out;
+	}
+
+	// init pool contents
+	pool->base = base;
+	pool->room = room;
+
+	// init stack contents
+	pool->addr = addr;
+	pool->head = 0;
+	pool->len = len;
+
+	// init memstack struct with stack indexes
+	for (int i = 0; i < len; i++) {
+		addr[i] = i;
+	}
+	//   head       len
+	//   |          |
+	//   v          v
+	// [ 0 1 2 .... n-1 ] // n elements
+
+	return pool;
+
+mem_pool_out:
+	free(addr);
+
+mem_stack_addr_out:
+
+	return NULL;
+}
+
+int allocate(struct mempool *pool, void **bufs, size_t nb_pkts)
+{
+	if ((pool->len - pool->head) < nb_pkts) {
+		// not enough buffers in mempool
+		return 0;
+	}
+
+	for (int i = 0; i < nb_pkts; i++) {
+		bufs[i] = pop(pool);
+	}
+
+	return nb_pkts;
+}
+
+void release(struct mempool *pool, void **bufs, size_t nb_pkts)
+{
+	for (int i = 0; i < nb_pkts; i++) {
+		push(pool, bufs[i]);
+	}
+}

--- a/src/router/driver/libbpf/mempool.h
+++ b/src/router/driver/libbpf/mempool.h
@@ -6,19 +6,19 @@
 #include <stdlib.h>
 
 struct mempool {
-	void *base;        // point to base memory address;
-	size_t room;       // size of each data room;
-	int len;           // total number of stack elements
+	uint64_t base;        // point to base memory address;
+	uint32_t room;        // size of each data room;
+	uint32_t len;         // total number of stack elements
 
 	// stack implement
-	int *addr;         // stack pointer, store index of umem buffers
+	uint64_t *addr;         // stack pointer, store index of umem buffers
 	int head;          // current head pointer
 };
 
-struct mempool *mempool_create(void *base, size_t len, size_t room);
-void release(struct mempool *pool, void **bufs, size_t nb_pkts);
-int allocate(struct mempool *pool, void **bufs, size_t nb_pkts);
-void *pop(struct mempool *pool);
-int push(struct mempool *pool, void *addr);
+struct mempool *mempool_create(uint64_t base, uint32_t len, uint32_t room);
+void release(struct mempool *pool, uint64_t *bufs, uint32_t nb_pkts);
+int allocate(struct mempool *pool, uint64_t *bufs, uint32_t nb_pkts);
+uint64_t pop(struct mempool *pool);
+int push(struct mempool *pool, uint64_t addr);
 
 #endif //__GLASNOSTIC_MEMPOOL_H__

--- a/src/router/driver/libbpf/mempool.h
+++ b/src/router/driver/libbpf/mempool.h
@@ -1,0 +1,24 @@
+// +build linux
+
+#ifndef __GLASNOSTIC_MEMPOOL_H__
+#define __GLASNOSTIC_MEMPOOL_H__
+
+#include <stdlib.h>
+
+struct mempool {
+	void *base;        // point to base memory address;
+	size_t room;       // size of each data room;
+	int len;           // total number of stack elements
+
+	// stack implement
+	int *addr;         // stack pointer, store index of umem buffers
+	int head;          // current head pointer
+};
+
+struct mempool *mempool_create(void *base, size_t len, size_t room);
+void release(struct mempool *pool, void **bufs, size_t nb_pkts);
+int allocate(struct mempool *pool, void **bufs, size_t nb_pkts);
+void *pop(struct mempool *pool);
+int push(struct mempool *pool, void *addr);
+
+#endif //__GLASNOSTIC_MEMPOOL_H__

--- a/src/router/driver/libbpf/runner.c
+++ b/src/router/driver/libbpf/runner.c
@@ -208,11 +208,11 @@ int libbpf_xsk__exit(struct libbpf *ptr)
 // libbpf_xsk__kick_tx
 int libbpf_xsk__kick_tx(struct libbpf *ptr, uint16_t pkts)
 {
+	libbpf_xsk__pull_cq(ptr);
 	xsk_ring_prod__submit(&ptr->xsk->tx, pkts);
 	int res = sendto(xsk_socket__fd(ptr->xsk->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
 	if (res < 0 && !ignored(errno)) {
-		libbpf_xsk__pull_cq(ptr);
-		fprintf(stderr, "send packet to xsk_socket failed with \"%s\"\n", strerror(errno));
+		// fprintf(stderr, "send packet to xsk_socket failed with \"%s\"\n", strerror(errno));
 		res = -errno;
 	}
 	return res;
@@ -226,10 +226,10 @@ int libbpf_xsk__pull_rx(struct libbpf *ptr, size_t nb_pkts)
 	size_t received = 0;
 	// xsk_ring_cons__peek will return how many packets landing in RX
 	received = xsk_ring_cons__peek(rx, max_fetch(nb_pkts), &idx_rx);
-	fprintf(stderr, "Try to peek %d but got %d packets\n", max_fetch(nb_pkts), received);
+	// fprintf(stderr, "Try to peek %d but got %d packets\n", max_fetch(nb_pkts), received);
 	// fprintf(stderr, "RX: %d, FQ: %d\n", idx_rx, idx_fq);
-	ring_prod_msg("FQ", fq);
-	ring_cons_msg("RX", rx);
+	// ring_prod_msg("FQ", fq);
+	// ring_cons_msg("RX", rx);
 
 	if (!received) {
 		poll(&ptr->fds, 1, 100);

--- a/src/router/driver/libbpf/runner.c
+++ b/src/router/driver/libbpf/runner.c
@@ -94,11 +94,11 @@ struct libbpf *libbpf_xsk__init(char *ifname, int queue_id)
 	struct xsk_umem_config umem_config = {
 		.fill_size = LIBBPF_XSK_RING_PROD_NUM_DESCS,
 		.comp_size = LIBBPF_XSK_RING_CONS_NUM_DESCS,
-		.frame_size = LIBBPF_XSK_MEM_FRAME_SIZE,
+		.frame_size = LIBBPF_XSK_RING_FRAME_SIZE,
 		.frame_headroom = LIBBPF_XSK_RING_FRAME_HEADROOM,
 	};
 
-	xsk->umem = configure_xsk_umem(ifname, &umem_config, LIBBPF_XSK_MEMPOOL_NUM_FRAMES * LIBBPF_XSK_MEM_FRAME_SIZE);
+	xsk->umem = configure_xsk_umem(ifname, &umem_config, LIBBPF_XSK_MEMPOOL_NUM_FRAMES * LIBBPF_XSK_RING_FRAME_SIZE);
 	if (!xsk->umem) {
 		// allocate memory for umem ptr failed
 		ptr->err = E_ALLOC_UMEM_PTR;
@@ -106,7 +106,7 @@ struct libbpf *libbpf_xsk__init(char *ifname, int queue_id)
 	}
 
 	// create mempool object
-	ptr->pool = mempool_create((uint64_t)xsk->umem->buf, LIBBPF_XSK_MEMPOOL_NUM_FRAMES, LIBBPF_XSK_MEM_FRAME_SIZE);
+	ptr->pool = mempool_create((uint64_t)xsk->umem->buf, LIBBPF_XSK_MEMPOOL_NUM_FRAMES, LIBBPF_XSK_RING_FRAME_SIZE);
 	if (!ptr->pool) {
 		ptr->err = E_ALLOC_MEMPOOL;
 		goto init_out;

--- a/src/router/driver/libbpf/runner.c
+++ b/src/router/driver/libbpf/runner.c
@@ -21,17 +21,33 @@
 #include "libbpf.h"       // must from libbpf/libbpf.h
 #include "xsk.h"          // must from libbpf/xsk.h
 
-// configure_xsk_umem should allocate memory with given size
-static struct xsk_umem_ptr *configure_xsk_umem(char *ifname, __u64 size)
+static uint32_t idx_fq = 0;
+static uint32_t idx_rx = 0;
+
+static inline void ring_cons_msg(const char *msg, struct xsk_ring_cons *cons)
 {
-	void *buffer_addr = NULL;
-	struct xsk_umem_ptr *umem = calloc(1, sizeof(*umem));
-	if (!umem) {
+	fprintf(stderr, "%s: cached_prod %03d, producer %03d, cached_cons %03d, size %03d\n",
+			msg, cons->cached_prod, *cons->producer, cons->cached_cons, cons->size);
+}
+
+static inline void ring_prod_msg(const char *msg, struct xsk_ring_prod *prod)
+{
+	fprintf(stderr, "%s: cached_prod %03d, cached_cons %03d, consumer %03d, size %03d\n",
+			msg, prod->cached_prod, prod->cached_cons, *prod->consumer, prod->size);
+}
+
+// configure_xsk_umem should allocate memory with given size
+static struct xsk_umem_ptr *configure_xsk_umem(char *ifname, struct xsk_umem_config *umem_config, __u64 size)
+{
+	struct xsk_umem_ptr *umem_ptr = calloc(1, sizeof(*umem_ptr));
+	if (!umem_ptr) {
 		fprintf(stderr, "ERROR: allocate xsk_umem_ptr failed\n");
 		return NULL;
 	}
-	buffer_addr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
-	/* FIXME: still no idea why the memory allocated from aligned_alloc or 
+	void *buffer_addr = NULL;
+	buffer_addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+			   MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
+	/* FIXME: still no idea why the memory allocated from aligned_alloc or
 	 * mmap can't be free here. If I try to free it in following checks,
 	 * the free call would cause a SIGSEGV signal and crash our process.
 	 * For the time being, let the system recycle those memory for us.
@@ -40,15 +56,17 @@ static struct xsk_umem_ptr *configure_xsk_umem(char *ifname, __u64 size)
 		fprintf(stderr, "ERROR: allocate aligned memory failed\n");
 		return NULL;
 	}
-	struct xsk_umem_config *user_config = NULL; // just make the parameter meaningful
-	int ret = xsk_umem__create(&umem->umem, buffer_addr, size, &umem->fq, &umem->cq, user_config);
+
+	int ret = xsk_umem__create(&umem_ptr->umem, buffer_addr, size,
+				   &umem_ptr->fq, &umem_ptr->cq, umem_config);
 	if (ret != 0) {
 		fprintf(stderr, "ERROR: create xsk_umem__create failed\n");
-		fprintf(stderr, "       error code %d:\"%s\" \n", ret, strerror(errno));
+		fprintf(stderr, "       error code %d:\"%s\" \n",
+			ret, strerror(errno));
 		return NULL;
 	}
-	umem->buf = buffer_addr;
-	return umem;
+	umem_ptr->buf = buffer_addr;
+	return umem_ptr;
 }
 
 // libbpf_xsk__init
@@ -60,7 +78,7 @@ struct libbpf *libbpf_xsk__init(char *ifname, int queue_id)
 	// create libbpf pointer object
 	struct libbpf *ptr = calloc(1, sizeof(*ptr));
 	if (!ptr) {
-		goto out;
+		goto init_out;
 	}
 
 	// create xsk_sock_ptr object
@@ -68,52 +86,60 @@ struct libbpf *libbpf_xsk__init(char *ifname, int queue_id)
 	if (!xsk) {
 		// failed to allocate memory for socket ptr
 		ptr->err = E_ALLOC_XSK_PTR;
-		goto out;
+		goto init_out;
 	}
 
 	// allocate and register umem to xsk_sock_ptr object
 	// also create umem mempool
-	xsk->umem = configure_xsk_umem(ifname, NUM_FRAMES * XSK_UMEM__DEFAULT_FRAME_SIZE);
+	struct xsk_umem_config umem_config = {
+		.fill_size = LIBBPF_XSK_RING_PROD_NUM_DESCS,
+		.comp_size = LIBBPF_XSK_RING_CONS_NUM_DESCS,
+		.frame_size = LIBBPF_XSK_MEM_FRAME_SIZE,
+		.frame_headroom = LIBBPF_XSK_RING_FRAME_HEADROOM,
+	};
+
+	xsk->umem = configure_xsk_umem(ifname, &umem_config, LIBBPF_XSK_MEMPOOL_NUM_FRAMES * LIBBPF_XSK_MEM_FRAME_SIZE);
 	if (!xsk->umem) {
 		// allocate memory for umem ptr failed
 		ptr->err = E_ALLOC_UMEM_PTR;
-		goto out;
+		goto init_out;
 	}
 
 	// create mempool object
-	ptr->pool = mempool_create(xsk->umem->buf, NUM_FRAMES, XSK_UMEM__DEFAULT_FRAME_SIZE);
+	ptr->pool = mempool_create((uint64_t)xsk->umem->buf, LIBBPF_XSK_MEMPOOL_NUM_FRAMES, LIBBPF_XSK_MEM_FRAME_SIZE);
 	if (!ptr->pool) {
 		ptr->err = E_ALLOC_MEMPOOL;
-		goto out;
+		goto init_out;
 	}
 
 	// create inqueue object
-	ptr->inqueue = calloc(FRAME_BATCH_SIZE, sizeof(struct membuf));
+	ptr->inqueue = calloc(LIBBPF_XSK_RING_BATCH_SIZE, sizeof(struct membuf));
 	if (!ptr->inqueue) {
 		ptr->err = E_ALLOC_INQUEUE;
-		goto out;
+		goto init_out;
 	}
 	// create bufs cache
-	ptr->bufs = calloc(FRAME_BATCH_SIZE, sizeof(void *));
+	ptr->bufs = calloc(LIBBPF_XSK_RING_BATCH_SIZE, sizeof(uint64_t));
 	if (!ptr->bufs) {
 		ptr->err = E_ALLOC_MEM_BUFS;
-		goto out;
+		goto init_out;
 	}
 
 	// setup cfg content
-	struct xsk_socket_config cfg;
-	cfg.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS;
-	cfg.tx_size = XSK_RING_PROD__DEFAULT_NUM_DESCS;
-	cfg.libbpf_flags = 0;
-	cfg.xdp_flags = opt_xdp_flags;
-	cfg.bind_flags = opt_xdp_bind_flags;
+	struct xsk_socket_config cfg = {
+		.rx_size = LIBBPF_XSK_RING_CONS_NUM_DESCS,
+		.tx_size = LIBBPF_XSK_RING_PROD_NUM_DESCS,
+		.libbpf_flags = 0,
+		.xdp_flags = opt_xdp_flags,
+		.bind_flags = opt_xdp_bind_flags,
+	};
 
 	// create AF_XDP socket
 	if (xsk_socket__create(&xsk->xsk, ifname, queue_id, xsk->umem->umem, &xsk->rx, &xsk->tx, &cfg) != 0) {
 		// failed to create AF_XDP socket
 		fprintf(stderr, "ERROR: xsk_socket__create failed\n");
 		ptr->err = E_CREATE_XSK;
-		goto out;
+		goto init_out;
 	}
 
 	// get nic index by its name
@@ -122,7 +148,7 @@ struct libbpf *libbpf_xsk__init(char *ifname, int queue_id)
 		// failed to get nic index
 		fprintf(stderr, "ERROR: if_nametoindex failed\n");
 		ptr->err = E_GET_NIC_IDX;
-		goto out;
+		goto init_out;
 	}
 
 	// link bpf for AF_XDP
@@ -130,31 +156,30 @@ struct libbpf *libbpf_xsk__init(char *ifname, int queue_id)
 		// failed to link bpf for AF_XDP
 		fprintf(stderr, "ERROR: bpf_get_link_xdp_id failed\n");
 		ptr->err = E_LINK_BPF_TO_XSK;
-		goto out;
+		goto init_out;
 	}
 
 	// reserve producer buffer for FQ
-	int idx_fq = 0;
-	if (xsk_ring_prod__reserve(&xsk->umem->fq, XSK_RING_PROD__DEFAULT_NUM_DESCS, &idx_fq) != XSK_RING_PROD__DEFAULT_NUM_DESCS) {
+	if (xsk_ring_prod__reserve(&xsk->umem->fq, LIBBPF_XSK_RING_PROD_NUM_DESCS, &idx_fq) != LIBBPF_XSK_RING_PROD_NUM_DESCS) {
 		// failed to reserve producer buffer
 		ptr->err = E_RESERVE_FQ_BUF;
-		goto out;
+		goto init_out;
 	}
 
 	// init fq ring addresses
-	for (int i = 0; i < XSK_RING_PROD__DEFAULT_NUM_DESCS; i++) {
-		*xsk_ring_prod__fill_addr(&xsk->umem->fq, idx_fq++) = (uint64_t)pop(ptr->pool);
+	for (int i = 0; i < LIBBPF_XSK_RING_PROD_NUM_DESCS; i++) {
+		*xsk_ring_prod__fill_addr(&xsk->umem->fq, idx_fq++) = pop(ptr->pool);
 	}
 
 	// move FQ producer ptr forward, to let kernel know there's more free
 	// spaces can pass packets in
-	xsk_ring_prod__submit(&xsk->umem->fq, XSK_RING_PROD__DEFAULT_NUM_DESCS);
+	xsk_ring_prod__submit(&xsk->umem->fq, LIBBPF_XSK_RING_PROD_NUM_DESCS);
 	
 	ptr->xsk = xsk;
-	ptr->fds.fd = xsk_socket__fd(ptr->xsk->xsk);
+	ptr->fds.fd = xsk_socket__fd(xsk->xsk);
 	ptr->fds.events = POLLIN;
 
-out:
+init_out:
 	return ptr;
 }
 
@@ -180,8 +205,8 @@ int libbpf_xsk__exit(struct libbpf *ptr)
 	return 0;
 }
 
-// kick_tx
-int kick_tx(struct libbpf *ptr, uint16_t pkts)
+// libbpf_xsk__kick_tx
+int libbpf_xsk__kick_tx(struct libbpf *ptr, uint16_t pkts)
 {
 	xsk_ring_prod__submit(&ptr->xsk->tx, pkts);
 	int res = sendto(xsk_socket__fd(ptr->xsk->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
@@ -193,18 +218,22 @@ int kick_tx(struct libbpf *ptr, uint16_t pkts)
 	return res;
 }
 
-// libbpf_xsk__poll check how many pakcets in RX and move them into inqueue
-int libbpf_xsk__poll(struct libbpf *ptr, size_t nb_pkts)
+// libbpf_xsk__pull_rx check how many pakcets in RX and move them into inqueue
+int libbpf_xsk__pull_rx(struct libbpf *ptr, size_t nb_pkts)
 {
 	struct xsk_ring_cons *rx = &ptr->xsk->rx;
+	struct xsk_ring_prod *fq = &ptr->xsk->umem->fq;
 	size_t received = 0;
-	uint32_t idx_rx = 0;
-	uint32_t idx_fq = 0;
 	// xsk_ring_cons__peek will return how many packets landing in RX
-	received = xsk_ring_cons__peek(&ptr->xsk->rx, nb_pkts, &idx_rx);
+	received = xsk_ring_cons__peek(rx, max_fetch(nb_pkts), &idx_rx);
+	fprintf(stderr, "Try to peek %d but got %d packets\n", max_fetch(nb_pkts), received);
+	// fprintf(stderr, "RX: %d, FQ: %d\n", idx_rx, idx_fq);
+	ring_prod_msg("FQ", fq);
+	ring_cons_msg("RX", rx);
+
 	if (!received) {
-		poll(&ptr->fds, 1, 1000);
-		goto poll_empty;
+		poll(&ptr->fds, 1, 100);
+		goto pull_rx_empty;
 	}
 
 	// ===== try to fill up FQ as much as possible =====
@@ -215,41 +244,38 @@ int libbpf_xsk__poll(struct libbpf *ptr, size_t nb_pkts)
 
 	// 1. prepare membuf from mempool
 	if (!allocate(ptr->pool, ptr->bufs, nb_pkts)) {
-		goto poll_out;
+		goto pull_rx_out;
 	}
 
 	// xsk_ring_prod__reserver will return 0 (if buffer not enough) or just
 	// the number we asked.
 	// reserve nb_pkts xsk desc from FQ
 	// if failed, release those membuf and skipping fill FQ
-	if (!xsk_ring_prod__reserve(&ptr->xsk->umem->fq, nb_pkts, &idx_fq)) {
+	if (!xsk_ring_prod__reserve(fq, nb_pkts, &idx_fq)) {
 		release(ptr->pool, ptr->bufs, nb_pkts);
-		goto poll_out;
+		goto pull_rx_out;
 	}
 
 	// fill FQ with nb_pkts buffers
 	for (int i = 0; i < nb_pkts; i++) {
-		__u64 *fq_addr;
-		uint64_t addr;
-
-		fq_addr = xsk_ring_prod__fill_addr(&ptr->xsk->umem->fq, idx_fq++);
-		addr = (uint64_t)ptr->bufs[i];
-		*fq_addr = addr;
+		*xsk_ring_prod__fill_addr(&ptr->xsk->umem->fq, idx_fq++) = (uint64_t)ptr->bufs[i];
 	}
 
 	xsk_ring_prod__submit(&ptr->xsk->umem->fq, nb_pkts);
 
-poll_out:
+pull_rx_out:
 
+	ptr->current_cached = received;
+	ptr->current = 0;
 	// read packets from RX to inqueue
 	for (int i = 0; i < received; i++) {
 		const struct xdp_desc *desc = xsk_ring_cons__rx_desc(rx, idx_rx++);
-		ptr->inqueue[i].addr = (void *)desc->addr;
+		ptr->inqueue[i].addr = desc->addr;
 		ptr->inqueue[i].len = desc->len;
 	}
 	xsk_ring_cons__release(&ptr->xsk->rx, received);
 
-poll_empty:
+pull_rx_empty:
 	return received;
 }
 
@@ -259,28 +285,28 @@ int libbpf_xsk__pull_cq(struct libbpf *ptr)
 	struct xsk_ring_cons *cq = &ptr->xsk->umem->cq;
 	uint32_t idx_cq = 0;
 
-	size_t n = xsk_ring_cons__peek(cq, FRAME_BATCH_SIZE, &idx_cq);
+	size_t n = xsk_ring_cons__peek(cq, LIBBPF_XSK_RING_BATCH_SIZE, &idx_cq);
 
 	for (int i = 0; i < n; i++) {
-		void *addr = (void *)xsk_ring_cons__comp_addr(cq, idx_cq++);
+		uint64_t addr = *xsk_ring_cons__comp_addr(cq, idx_cq++);
 		push(ptr->pool, addr);
 	}
 
 	xsk_ring_cons__release(cq, n);
-	ptr->current = 0;
 	return n;
 }
 
 // libbpf_xsk__pkt_read read current mbuf from the inqueue
-int libbpf_xsk__pkt_read(const struct libbpf *ptr, uintptr_t bptr)
+uint32_t libbpf_xsk__pkt_read(const struct libbpf *ptr, uintptr_t bptr)
 {
-	if (ptr->current >= FRAME_BATCH_SIZE) {
+	// unlikely
+	if (ptr->current >= ptr->current_cached) {
 		return 0;
 	}
 
 	unsigned char ** bufptr = (unsigned char **)bptr;
 	const struct membuf *buf = &ptr->inqueue[ptr->current];
-	uint64_t addr = (uint64_t)buf->addr;
+	uint64_t addr = buf->addr;
 	uint32_t len = buf->len;
 
 	*bufptr = xsk_umem__get_data(ptr->xsk->umem->buf, addr);
@@ -289,28 +315,28 @@ int libbpf_xsk__pkt_read(const struct libbpf *ptr, uintptr_t bptr)
 }
 
 // libbpf_xsk__pkt_write allocate a new membuf, write data into it
-// move new membuf to tx, trigger kick_tx
+// move new membuf to tx, trigger libbpf_xsk__kick_tx
 int libbpf_xsk__pkt_write(struct libbpf *ptr, const unsigned char *buf, const size_t len)
 {
 	// If buf addr is the same as "current", we just pass this pkt buffer
 	// to tx. If buf addr is not the same as "current", we copy the content
 	// from it and move the pkt buffer to tx.
-	// 
+	//
 	// 1. Copy content from buf to current if it's not the same addr
 	// 2. move pkt buffer to tx
-	// 3. trigger kick_tx
+	// 3. trigger libbpf_xsk__kick_tx
 	//
 	int current = ptr->current;
-	if ((uint64_t)ptr->inqueue[current].addr != (uint64_t)buf) {
-		memcpy((void *)ptr->inqueue[current].addr, buf, len);
+	void * addr = xsk_umem__get_data(ptr->xsk->umem->buf, ptr->inqueue[current].addr);
+	if ((uint64_t)addr != (uint64_t)buf) {
+		memcpy(addr, buf, len);
 	}
 	ptr->inqueue[current].len = len;
 
 	return libbpf_xsk__pkt_pass(ptr, buf, len);
 }
 
-// libbpf_xsk__pkt_pass move current membuf from rx to tx and trigger kick_tx
-// WIP:
+// libbpf_xsk__pkt_pass move current membuf from rx to tx and trigger libbpf_xsk__kick_tx
 int libbpf_xsk__pkt_pass(struct libbpf *ptr, const unsigned char *buf, const size_t len)
 {
 	// move current inqueue memory to TX
@@ -322,7 +348,7 @@ int libbpf_xsk__pkt_pass(struct libbpf *ptr, const unsigned char *buf, const siz
 	struct xdp_desc *desc = xsk_ring_prod__tx_desc(&ptr->xsk->tx, idx_tx);
 	desc->len = len;
 	desc->addr = (uint64_t)ptr->inqueue[current].addr;
-	return kick_tx(ptr, 1);
+	return libbpf_xsk__kick_tx(ptr, 1);
 }
 
 // libbpf_xsk__pkt_drop release current membuf from rx back to mempool
@@ -330,4 +356,12 @@ int libbpf_xsk__pkt_drop(struct libbpf *ptr)
 {
 	// release current inqueue memory back to mempool
 	return push(ptr->pool, ptr->inqueue[ptr->current++].addr);
+}
+
+void report_ring(struct libbpf *ptr)
+{
+	ring_prod_msg("FQ", &ptr->xsk->umem->fq);
+	ring_cons_msg("RX", &ptr->xsk->rx);
+	ring_prod_msg("TX", &ptr->xsk->tx);
+	ring_cons_msg("CQ", &ptr->xsk->umem->cq);
 }

--- a/src/router/driver/libbpf/runner.c
+++ b/src/router/driver/libbpf/runner.c
@@ -6,40 +6,20 @@
 #include <net/if.h>       // for if_nametoindex
 #include <unistd.h>       // for getpagesize
 #include <string.h>       // for memcpy, strerror
+#include <poll.h>         // for pollfds
 #include <sys/types.h>    // for sendto
 #include <sys/socket.h>   // for sendto
 #include <sys/mman.h>     // for mmap
 #include <linux/if_xdp.h> // for xdp_desc
-#include <poll.h>         // for pollfds
 #include <uapi/linux/if_link.h> // for XDP_FLAGS, XDP_FLAGS_SKB_MODE
 
-#include "runner.h"       // for self-defined function declaration
-#include "xdp.h"          // for self-defined data structure declaration
-#include "errors.h"       // for self-defined error-number declaration
+#include "runner.h"       // for exported CGO function declaration
+#include "xdp.h"          // for data structure declaration
+#include "errors.h"       // for error-number declaration
+#include "mempool.h"      // for memory pool implementation
 
 #include "libbpf.h"       // must from libbpf/libbpf.h
 #include "xsk.h"          // must from libbpf/xsk.h
-
-#define NUM_FRAMES			(1U << 12)
-#define BURST_SIZE			(NUM_FRAMES >> 2)
-#define FRAME_BATCH_SIZE		(BURST_SIZE >> 2)
-#define SINGLE_FRAME			1
-
-static struct xsk_sock_ptr* xsk_ptr = NULL;
-static struct pollfd fds;
-__u32 rx_idx = 0;
-__u32 fq_idx = 0;
-__u32 cq_idx = 0;
-
-static inline size_t max_fetch(size_t request_frames)
-{
-	return (FRAME_BATCH_SIZE > request_frames) ? request_frames : FRAME_BATCH_SIZE;
-}
-
-static inline bool ignored(int n)
-{
-	return n == ENOBUFS || n == EAGAIN || n == EBUSY;
-}
 
 // configure_xsk_umem should allocate memory with given size
 static struct xsk_umem_ptr *configure_xsk_umem(char *ifname, __u64 size)
@@ -50,18 +30,18 @@ static struct xsk_umem_ptr *configure_xsk_umem(char *ifname, __u64 size)
 		fprintf(stderr, "ERROR: allocate xsk_umem_ptr failed\n");
 		return NULL;
 	}
-	// buffer_addr = aligned_alloc(getpagesize(), size);
 	buffer_addr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
-	/* FIXME: still no idea why the memory allocated from aligned_alloc
-	 * can't be free. If I try to free it in following checks, the free
-	 * calls would cause a SIGSEGV signal and crash our process. For the
-	 * time being, let the system recycle those memory for us.
+	/* FIXME: still no idea why the memory allocated from aligned_alloc or 
+	 * mmap can't be free here. If I try to free it in following checks,
+	 * the free call would cause a SIGSEGV signal and crash our process.
+	 * For the time being, let the system recycle those memory for us.
 	 */
 	if (!buffer_addr) {
 		fprintf(stderr, "ERROR: allocate aligned memory failed\n");
 		return NULL;
 	}
-	int ret = xsk_umem__create(&umem->umem, buffer_addr, size, &umem->fq, &umem->cq, NULL);
+	struct xsk_umem_config *user_config = NULL; // just make the parameter meaningful
+	int ret = xsk_umem__create(&umem->umem, buffer_addr, size, &umem->fq, &umem->cq, user_config);
 	if (ret != 0) {
 		fprintf(stderr, "ERROR: create xsk_umem__create failed\n");
 		fprintf(stderr, "       error code %d:\"%s\" \n", ret, strerror(errno));
@@ -71,32 +51,57 @@ static struct xsk_umem_ptr *configure_xsk_umem(char *ifname, __u64 size)
 	return umem;
 }
 
-// init_afxdp_with_libbpf
-int init_afxdp_with_libbpf(char *ifname, int queue_id)
+// libbpf_xsk__init
+struct libbpf *libbpf_xsk__init(char *ifname, int queue_id)
 {
-	struct xsk_socket_config cfg;
 	__u32 opt_xdp_flags = XDP_FLAGS_SKB_MODE;
 	__u32 opt_xdp_bind_flags = 0;
 
-	// create xsk_sock_ptr object
-	struct xsk_sock_ptr *xsk = NULL;
-	if (xsk_ptr != NULL) {
-		return E_ALREADY_INITED;
+	// create libbpf pointer object
+	struct libbpf *ptr = calloc(1, sizeof(*ptr));
+	if (!ptr) {
+		goto out;
 	}
-	xsk = calloc(1, sizeof(*xsk));
+
+	// create xsk_sock_ptr object
+	struct xsk_sock_ptr *xsk = calloc(1, sizeof(*xsk));
 	if (!xsk) {
 		// failed to allocate memory for socket ptr
-		return E_ALLOC_XSK_PTR;
+		ptr->err = E_ALLOC_XSK_PTR;
+		goto out;
 	}
 
 	// allocate and register umem to xsk_sock_ptr object
+	// also create umem mempool
 	xsk->umem = configure_xsk_umem(ifname, NUM_FRAMES * XSK_UMEM__DEFAULT_FRAME_SIZE);
 	if (!xsk->umem) {
 		// allocate memory for umem ptr failed
-		return E_ALLOC_UMEM_PTR;
+		ptr->err = E_ALLOC_UMEM_PTR;
+		goto out;
+	}
+
+	// create mempool object
+	ptr->pool = mempool_create(xsk->umem->buf, NUM_FRAMES, XSK_UMEM__DEFAULT_FRAME_SIZE);
+	if (!ptr->pool) {
+		ptr->err = E_ALLOC_MEMPOOL;
+		goto out;
+	}
+
+	// create inqueue object
+	ptr->inqueue = calloc(FRAME_BATCH_SIZE, sizeof(struct membuf));
+	if (!ptr->inqueue) {
+		ptr->err = E_ALLOC_INQUEUE;
+		goto out;
+	}
+	// create bufs cache
+	ptr->bufs = calloc(FRAME_BATCH_SIZE, sizeof(void *));
+	if (!ptr->bufs) {
+		ptr->err = E_ALLOC_MEM_BUFS;
+		goto out;
 	}
 
 	// setup cfg content
+	struct xsk_socket_config cfg;
 	cfg.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS;
 	cfg.tx_size = XSK_RING_PROD__DEFAULT_NUM_DESCS;
 	cfg.libbpf_flags = 0;
@@ -107,7 +112,8 @@ int init_afxdp_with_libbpf(char *ifname, int queue_id)
 	if (xsk_socket__create(&xsk->xsk, ifname, queue_id, xsk->umem->umem, &xsk->rx, &xsk->tx, &cfg) != 0) {
 		// failed to create AF_XDP socket
 		fprintf(stderr, "ERROR: xsk_socket__create failed\n");
-		return E_CREATE_XSK;
+		ptr->err = E_CREATE_XSK;
+		goto out;
 	}
 
 	// get nic index by its name
@@ -115,157 +121,213 @@ int init_afxdp_with_libbpf(char *ifname, int queue_id)
 	if (!xsk->nicindex) {
 		// failed to get nic index
 		fprintf(stderr, "ERROR: if_nametoindex failed\n");
-		return E_GET_NIC_IDX;
+		ptr->err = E_GET_NIC_IDX;
+		goto out;
 	}
 
 	// link bpf for AF_XDP
 	if (bpf_get_link_xdp_id(xsk->nicindex, &(xsk->prog_id), opt_xdp_flags) != 0) {
 		// failed to link bpf for AF_XDP
 		fprintf(stderr, "ERROR: bpf_get_link_xdp_id failed\n");
-		return E_LINK_BPF_TO_XSK;
+		ptr->err = E_LINK_BPF_TO_XSK;
+		goto out;
 	}
 
 	// reserve producer buffer for FQ
-	if (xsk_ring_prod__reserve(&xsk->umem->fq, XSK_RING_PROD__DEFAULT_NUM_DESCS, &fq_idx) != XSK_RING_PROD__DEFAULT_NUM_DESCS) {
+	int idx_fq = 0;
+	if (xsk_ring_prod__reserve(&xsk->umem->fq, XSK_RING_PROD__DEFAULT_NUM_DESCS, &idx_fq) != XSK_RING_PROD__DEFAULT_NUM_DESCS) {
 		// failed to reserve producer buffer
-		return E_RESERVE_FQ_BUF;
+		ptr->err = E_RESERVE_FQ_BUF;
+		goto out;
 	}
 
 	// init fq ring addresses
-	for (int i = 0; i < XSK_RING_PROD__DEFAULT_NUM_DESCS * XSK_UMEM__DEFAULT_FRAME_SIZE; i += XSK_UMEM__DEFAULT_FRAME_SIZE) {
-		*xsk_ring_prod__fill_addr(&xsk->umem->fq, fq_idx++) = i;
+	for (int i = 0; i < XSK_RING_PROD__DEFAULT_NUM_DESCS; i++) {
+		*xsk_ring_prod__fill_addr(&xsk->umem->fq, idx_fq++) = (uint64_t)pop(ptr->pool);
 	}
 
 	// move FQ producer ptr forward, to let kernel know there's more free
 	// spaces can pass packets in
 	xsk_ring_prod__submit(&xsk->umem->fq, XSK_RING_PROD__DEFAULT_NUM_DESCS);
 	
-	// store xsk_ptr
-	xsk_ptr = xsk;
+	ptr->xsk = xsk;
+	ptr->fds.fd = xsk_socket__fd(ptr->xsk->xsk);
+	ptr->fds.events = POLLIN;
 
-	// setup pollfds
-	fds.fd = xsk_socket__fd(xsk_ptr->xsk);
-	fds.events = POLLIN;
-
-	return 0;
+out:
+	return ptr;
 }
 
-// exit_afxdp_with_libbpf
-int exit_afxdp_with_libbpf()
+// libbpf_xsk__exit
+int libbpf_xsk__exit(struct libbpf *ptr)
 {
-	if (NULL == xsk_ptr) {
-		// xsk_ptr not existed, can't clean up
+	if (NULL == ptr || NULL == ptr->xsk) {
 		return -1; // FIXME: return error number
 	}
-	xsk_socket__delete(xsk_ptr->xsk);
-	xsk_umem__delete(xsk_ptr->umem->umem);
+	xsk_socket__delete(ptr->xsk->xsk);
+	xsk_umem__delete(ptr->xsk->umem->umem);
 	__u32 curr_prog_id = 0;
 
-	if (bpf_get_link_xdp_id(xsk_ptr->nicindex, &curr_prog_id, XDP_FLAGS_UPDATE_IF_NOEXIST)){
+	if (bpf_get_link_xdp_id(ptr->xsk->nicindex, &curr_prog_id, XDP_FLAGS_UPDATE_IF_NOEXIST)){
 		// can't get curr_prog_id of nic or not existed
 		return -1; // should return different error code
 	}
 
-	if (xsk_ptr->prog_id == curr_prog_id) {
-		bpf_set_link_xdp_fd(xsk_ptr->nicindex, -1, XDP_FLAGS_UPDATE_IF_NOEXIST);
-		xsk_ptr = NULL;
+	if (ptr->xsk->prog_id == curr_prog_id) {
+		bpf_set_link_xdp_fd(ptr->xsk->nicindex, -1, XDP_FLAGS_UPDATE_IF_NOEXIST);
 	}
 
 	return 0;
 }
 
-int poll_libbpf()
+// kick_tx
+int kick_tx(struct libbpf *ptr, uint16_t pkts)
 {
-	return poll(&fds, 1, 100);
-}
-
-int poll_packets_with_libbpf(size_t request_frames)
-{
-	int ret = 0;
-	uint16_t rx_pkts_number = xsk_ring_cons__peek(&xsk_ptr->rx, max_fetch(request_frames), &rx_idx);
-	if (rx_pkts_number == 0) {
-		return 0;
-	}
-
-	do {
-		ret = xsk_ring_prod__reserve(&xsk_ptr->umem->fq, rx_pkts_number, &fq_idx);
-	} while(ret != rx_pkts_number);
-
-	return rx_pkts_number;
-}
-
-int read_packet_from_fq_torx_with_libbpf(uintptr_t bptr)
-{
-	unsigned char ** bufptr = (unsigned char **)bptr;
-	const struct xdp_desc *rx_desc = xsk_ring_cons__rx_desc(&xsk_ptr->rx, rx_idx);
-	uint64_t addr = rx_desc->addr;
-	uint32_t len = rx_desc->len;
-	*bufptr = xsk_umem__get_data(xsk_ptr->umem->buf, addr);
-	return len;
-}
-
-void drop_rx_packet_to_fq()
-{
-	const struct xdp_desc *rx_desc = xsk_ring_cons__rx_desc(&xsk_ptr->rx, rx_idx);
-	uint64_t addr = rx_desc->addr;
-	*xsk_ring_prod__fill_addr(&xsk_ptr->umem->fq, fq_idx++) = addr;
-}
-
-int pass_rx_packet_to_tx(uint32_t len)
-{
-	__u32 tx_idx = 0;
-	struct xdp_desc *tx_desc;
-
-	int ret = xsk_ring_prod__reserve(&xsk_ptr->tx, SINGLE_FRAME, &tx_idx);
-	if (ret != SINGLE_FRAME) {
-		return 0;
-	}
-	tx_desc = xsk_ring_prod__tx_desc(&xsk_ptr->tx, tx_idx);
-	const struct xdp_desc *rx_desc = xsk_ring_cons__rx_desc(&xsk_ptr->rx, rx_idx);
-	uint64_t addr = rx_desc->addr;
-	tx_desc->addr = addr;
-	tx_desc->len = len;
-	return ret;
-}
-
-int new_packet_with_libbpf(unsigned char * buf, size_t len)
-{
-	const struct xdp_desc *rx_desc = xsk_ring_cons__rx_desc(&xsk_ptr->rx, rx_idx);
-	void *pkt = xsk_umem__get_data(xsk_ptr->umem->buf, rx_desc->addr);
-	memcpy(pkt, buf, len);
-	return pass_rx_packet_to_tx(len);
-}
-
-void rx_fwd()
-{
-	rx_idx++;
-}
-
-int flush_tx(int num_frames)
-{
-	xsk_ring_prod__submit(&xsk_ptr->tx, num_frames);
-	int res = sendto(xsk_socket__fd(xsk_ptr->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
+	xsk_ring_prod__submit(&ptr->xsk->tx, pkts);
+	int res = sendto(xsk_socket__fd(ptr->xsk->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
 	if (res < 0 && !ignored(errno)) {
+		libbpf_xsk__pull_cq(ptr);
 		fprintf(stderr, "send packet to xsk_socket failed with \"%s\"\n", strerror(errno));
 		res = -errno;
 	}
 	return res;
 }
 
-void flush_fq(int num_frames)
+// libbpf_xsk__poll check how many pakcets in RX and move them into inqueue
+int libbpf_xsk__poll(struct libbpf *ptr, size_t nb_pkts)
 {
-	xsk_ring_prod__submit(&xsk_ptr->umem->fq, num_frames);
-}
-
-void flush_rx(int num_frames)
-{
-	xsk_ring_cons__release(&xsk_ptr->rx, num_frames);
-}
-
-void flush_cq(int num_frames)
-{
-	int txed_packets = xsk_ring_cons__peek(&xsk_ptr->umem->cq, num_frames, &cq_idx);
-	if (txed_packets > 0) {
-		xsk_ring_cons__release(&xsk_ptr->umem->cq, txed_packets);
+	struct xsk_ring_cons *rx = &ptr->xsk->rx;
+	size_t received = 0;
+	uint32_t idx_rx = 0;
+	uint32_t idx_fq = 0;
+	// xsk_ring_cons__peek will return how many packets landing in RX
+	received = xsk_ring_cons__peek(&ptr->xsk->rx, nb_pkts, &idx_rx);
+	if (!received) {
+		poll(&ptr->fds, 1, 1000);
+		goto poll_empty;
 	}
+
+	// ===== try to fill up FQ as much as possible =====
+	// 1. prepare membuf from mempool
+	// 2. reserve xsk desc from FQ, if failed release membuf from (1) back
+	//    to mempool
+	// 3. fill FQ with membuf addresses
+
+	// 1. prepare membuf from mempool
+	if (!allocate(ptr->pool, ptr->bufs, nb_pkts)) {
+		goto poll_out;
+	}
+
+	// xsk_ring_prod__reserver will return 0 (if buffer not enough) or just
+	// the number we asked.
+	// reserve nb_pkts xsk desc from FQ
+	// if failed, release those membuf and skipping fill FQ
+	if (!xsk_ring_prod__reserve(&ptr->xsk->umem->fq, nb_pkts, &idx_fq)) {
+		release(ptr->pool, ptr->bufs, nb_pkts);
+		goto poll_out;
+	}
+
+	// fill FQ with nb_pkts buffers
+	for (int i = 0; i < nb_pkts; i++) {
+		__u64 *fq_addr;
+		uint64_t addr;
+
+		fq_addr = xsk_ring_prod__fill_addr(&ptr->xsk->umem->fq, idx_fq++);
+		addr = (uint64_t)ptr->bufs[i];
+		*fq_addr = addr;
+	}
+
+	xsk_ring_prod__submit(&ptr->xsk->umem->fq, nb_pkts);
+
+poll_out:
+
+	// read packets from RX to inqueue
+	for (int i = 0; i < received; i++) {
+		const struct xdp_desc *desc = xsk_ring_cons__rx_desc(rx, idx_rx++);
+		ptr->inqueue[i].addr = (void *)desc->addr;
+		ptr->inqueue[i].len = desc->len;
+	}
+	xsk_ring_cons__release(&ptr->xsk->rx, received);
+
+poll_empty:
+	return received;
+}
+
+// libbpf_xsk__pull_cq check CQ sent packet, and push them back to mempool
+int libbpf_xsk__pull_cq(struct libbpf *ptr)
+{
+	struct xsk_ring_cons *cq = &ptr->xsk->umem->cq;
+	uint32_t idx_cq = 0;
+
+	size_t n = xsk_ring_cons__peek(cq, FRAME_BATCH_SIZE, &idx_cq);
+
+	for (int i = 0; i < n; i++) {
+		void *addr = (void *)xsk_ring_cons__comp_addr(cq, idx_cq++);
+		push(ptr->pool, addr);
+	}
+
+	xsk_ring_cons__release(cq, n);
+	ptr->current = 0;
+	return n;
+}
+
+// libbpf_xsk__pkt_read read current mbuf from the inqueue
+int libbpf_xsk__pkt_read(const struct libbpf *ptr, uintptr_t bptr)
+{
+	if (ptr->current >= FRAME_BATCH_SIZE) {
+		return 0;
+	}
+
+	unsigned char ** bufptr = (unsigned char **)bptr;
+	const struct membuf *buf = &ptr->inqueue[ptr->current];
+	uint64_t addr = (uint64_t)buf->addr;
+	uint32_t len = buf->len;
+
+	*bufptr = xsk_umem__get_data(ptr->xsk->umem->buf, addr);
+
+	return len;
+}
+
+// libbpf_xsk__pkt_write allocate a new membuf, write data into it
+// move new membuf to tx, trigger kick_tx
+int libbpf_xsk__pkt_write(struct libbpf *ptr, const unsigned char *buf, const size_t len)
+{
+	// If buf addr is the same as "current", we just pass this pkt buffer
+	// to tx. If buf addr is not the same as "current", we copy the content
+	// from it and move the pkt buffer to tx.
+	// 
+	// 1. Copy content from buf to current if it's not the same addr
+	// 2. move pkt buffer to tx
+	// 3. trigger kick_tx
+	//
+	int current = ptr->current;
+	if ((uint64_t)ptr->inqueue[current].addr != (uint64_t)buf) {
+		memcpy((void *)ptr->inqueue[current].addr, buf, len);
+	}
+	ptr->inqueue[current].len = len;
+
+	return libbpf_xsk__pkt_pass(ptr, buf, len);
+}
+
+// libbpf_xsk__pkt_pass move current membuf from rx to tx and trigger kick_tx
+// WIP:
+int libbpf_xsk__pkt_pass(struct libbpf *ptr, const unsigned char *buf, const size_t len)
+{
+	// move current inqueue memory to TX
+	int current = ptr->current++;
+	int idx_tx = 0;
+	if (!xsk_ring_prod__reserve(&ptr->xsk->tx, 1, &idx_tx)) {
+		return -1;
+	}
+	struct xdp_desc *desc = xsk_ring_prod__tx_desc(&ptr->xsk->tx, idx_tx);
+	desc->len = len;
+	desc->addr = (uint64_t)ptr->inqueue[current].addr;
+	return kick_tx(ptr, 1);
+}
+
+// libbpf_xsk__pkt_drop release current membuf from rx back to mempool
+int libbpf_xsk__pkt_drop(struct libbpf *ptr)
+{
+	// release current inqueue memory back to mempool
+	return push(ptr->pool, ptr->inqueue[ptr->current++].addr);
 }

--- a/src/router/driver/libbpf/runner.h
+++ b/src/router/driver/libbpf/runner.h
@@ -8,14 +8,16 @@
 
 #include "xdp.h"    // for self-defined data structure
 
-#define NUM_FRAMES			(1U << 12)
-#define BURST_SIZE			(NUM_FRAMES >> 2)
-#define FRAME_BATCH_SIZE		(BURST_SIZE >> 2)
-#define SINGLE_FRAME			1
+#define LIBBPF_XSK_MEMPOOL_NUM_FRAMES	(1U << 13) /* 4096 packets */
+#define LIBBPF_XSK_RING_PROD_NUM_DESCS	(1U << 12) /* 2048 packets */
+#define LIBBPF_XSK_RING_CONS_NUM_DESCS	(1U << 12) /* 2048 packets */
+#define LIBBPF_XSK_RING_FRAME_SIZE	(1U << 12) /* 2048 bytes */
+#define LIBBPF_XSK_RING_BATCH_SIZE	(LIBBPF_XSK_MEMPOOL_NUM_FRAMES >> 6)
+#define LIBBPF_XSK_RING_FRAME_HEADROOM	0
 
 static inline size_t max_fetch(size_t request)
 {
-	return (FRAME_BATCH_SIZE > request) ? request : FRAME_BATCH_SIZE;
+	return (LIBBPF_XSK_RING_BATCH_SIZE > request) ? request : LIBBPF_XSK_RING_BATCH_SIZE;
 }
 
 // libbpf_xsk__init
@@ -23,19 +25,23 @@ struct libbpf *libbpf_xsk__init(char *ifname, int queue_id);
 // libbpf_xsk__exit
 int libbpf_xsk__exit(struct libbpf *ptr);
 
-// libbpf_xsk__poll
-int libbpf_xsk__poll(struct libbpf *ptr, size_t nb_pkts);
+// libbpf_xsk__pull_rx
+int libbpf_xsk__pull_rx(struct libbpf *ptr, size_t nb_pkts);
 // libbpf_xsk__pull_cq
 int libbpf_xsk__pull_cq(struct libbpf *ptr);
+// libbpf_xsk__kick_tx
+int libbpf_xsk__kick_tx(struct libbpf *ptr, uint16_t pkts);
 
 // libbpf_xsk__pkt_read;
-int libbpf_xsk__pkt_read(const struct libbpf *ptr, uintptr_t bptr);
+uint32_t libbpf_xsk__pkt_read(const struct libbpf *ptr, uintptr_t bptr);
 // libbpf_xsk__pkt_write;
 int libbpf_xsk__pkt_write(struct libbpf *ptr, const unsigned char *buf, const size_t len);
 // libbpf_xsk__pkt_pass
 int libbpf_xsk__pkt_pass(struct libbpf *ptr, const unsigned char *buf, const size_t len);
 // libbpf_xsk__pkt_drop;
 int libbpf_xsk__pkt_drop(struct libbpf *ptr);
+
+void report_ring(struct libbpf *ptr);
 
 
 #endif /* __GLASNOSTIC_LIBBPF_H__ */

--- a/src/router/driver/libbpf/runner.h
+++ b/src/router/driver/libbpf/runner.h
@@ -8,29 +8,34 @@
 
 #include "xdp.h"    // for self-defined data structure
 
-// init_afxdp_with_libbpf
-int init_afxdp_with_libbpf(char *ifname, int queue);
-// exit_afxdp_with_libbpf
-int exit_afxdp_with_libbpf();
-// poll_packets_with_libbpf
-int poll_packets_with_libbpf(size_t request_frames);
-// int reserve_packets_from_fq(size_t rx_buf_number);
+#define NUM_FRAMES			(1U << 12)
+#define BURST_SIZE			(NUM_FRAMES >> 2)
+#define FRAME_BATCH_SIZE		(BURST_SIZE >> 2)
+#define SINGLE_FRAME			1
 
-int poll_libbpf();
+static inline size_t max_fetch(size_t request)
+{
+	return (FRAME_BATCH_SIZE > request) ? request : FRAME_BATCH_SIZE;
+}
 
-// read_packet_from_fq_torx_with_libbpf
-int read_packet_from_fq_torx_with_libbpf(uintptr_t bptr);
-// new_packet_with_libbpf
-int new_packet_with_libbpf(unsigned char * buf, size_t len);
+// libbpf_xsk__init
+struct libbpf *libbpf_xsk__init(char *ifname, int queue_id);
+// libbpf_xsk__exit
+int libbpf_xsk__exit(struct libbpf *ptr);
 
-int pass_rx_packet_to_tx(uint32_t len);
+// libbpf_xsk__poll
+int libbpf_xsk__poll(struct libbpf *ptr, size_t nb_pkts);
+// libbpf_xsk__pull_cq
+int libbpf_xsk__pull_cq(struct libbpf *ptr);
 
-void drop_rx_packet_to_fq();
+// libbpf_xsk__pkt_read;
+int libbpf_xsk__pkt_read(const struct libbpf *ptr, uintptr_t bptr);
+// libbpf_xsk__pkt_write;
+int libbpf_xsk__pkt_write(struct libbpf *ptr, const unsigned char *buf, const size_t len);
+// libbpf_xsk__pkt_pass
+int libbpf_xsk__pkt_pass(struct libbpf *ptr, const unsigned char *buf, const size_t len);
+// libbpf_xsk__pkt_drop;
+int libbpf_xsk__pkt_drop(struct libbpf *ptr);
 
-int flush_tx(int num_frames);
-void flush_fq(int num_frames);
-void flush_cq(int num_frames);
-void flush_rx(int num_frames);
-void rx_fwd();
 
 #endif /* __GLASNOSTIC_LIBBPF_H__ */

--- a/src/router/driver/libbpf/runner_linux.go
+++ b/src/router/driver/libbpf/runner_linux.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -30,7 +31,6 @@ import (
 const (
 	DefaultCombinedQueueID = 0
 	BatchFrames            = 1 << 4 // the maximum number of frame we tell AF_XDP we want fetch per poll
-	// BatchFrames            = 1 << 10 // the maximum number of frame we tell AF_XDP we want fetch per poll
 )
 
 const (
@@ -52,15 +52,12 @@ func init() {
 }
 
 type libbpfRunnerLinux struct {
+	libbpf    *C.struct_libbpf
 	flag      uint64
 	incomming chan Packet // channel for incomming packets
 	next      chan bool   // single signal control of incomming packets
 
 	*sync.WaitGroup
-
-	dropped  int
-	passed   int
-	injected int
 }
 
 func newRunner(ifName string) (*libbpfRunnerLinux, error) {
@@ -81,21 +78,22 @@ func (l *libbpfRunnerLinux) Read() <-chan Packet {
 }
 
 func (l *libbpfRunnerLinux) Pass(pkt Packet) {
-	res := int(C.pass_rx_packet_to_tx(C.uint(len(pkt))))
-	l.passed += res
+	// write the packet
+	slice := (*reflect.SliceHeader)(unsafe.Pointer(&pkt))
+	C.libbpf_xsk__pkt_pass(l.libbpf, (*C.uchar)(unsafe.Pointer(slice.Data)), C.size_t(len(pkt)))
 	l.complete()
 }
 
 func (l *libbpfRunnerLinux) New(pkt Packet) {
+	// write new data to current buffer
 	slice := (*reflect.SliceHeader)(unsafe.Pointer(&pkt))
-	C.new_packet_with_libbpf((*C.uchar)(unsafe.Pointer(slice.Data)), C.size_t(len(pkt)))
-	l.injected++
+	C.libbpf_xsk__pkt_write(l.libbpf, (*C.uchar)(unsafe.Pointer(slice.Data)), C.size_t(len(pkt)))
 	l.complete()
 }
 
 func (l *libbpfRunnerLinux) Drop() {
-	C.drop_rx_packet_to_fq()
-	l.dropped++
+	// we have to record the current packet been dropped correctly
+	C.libbpf_xsk__pkt_drop(l.libbpf)
 	l.complete()
 }
 
@@ -103,15 +101,19 @@ func (l *libbpfRunnerLinux) Close() {
 	close(l.next)
 	atomic.StoreUint64(&l.flag, stop)
 	l.Wait()
-	C.exit_afxdp_with_libbpf()
+	C.libbpf_xsk__exit(l.libbpf)
 }
 
 func (l *libbpfRunnerLinux) init(ifName string) error {
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cIfName))
 
-	if ret := int(C.init_afxdp_with_libbpf(cIfName, C.int(CombinedQueueID))); ret != 0 {
-		return initErrors[ret]
+	l.libbpf = C.libbpf_xsk__init(cIfName, C.int(CombinedQueueID))
+	if l.libbpf == nil {
+		return ErrInvalidLibbpf
+	}
+	if l.libbpf.err != 0 {
+		return afxdpErrors[int(l.libbpf.err)]
 	}
 	l.flag = process
 	// worker keep fetching packet from XSK
@@ -122,26 +124,24 @@ func (l *libbpfRunnerLinux) init(ifName string) error {
 }
 
 func (l *libbpfRunnerLinux) worker() {
+	// mark this worker should take one OS thread for reducing
+	// 1. don't migrate to other OS thread
+	// 2. take one OS thread resource
+	runtime.LockOSThread()
+
 	defer l.Done()
 	log.Println("Libbpf runner worker starting")
 	defer log.Println("Libbpf runner worker returned")
 	for atomic.LoadUint64(&l.flag) == process {
-		if int(C.poll_libbpf()) <= 0 {
-			continue
-		}
-		total := int(C.poll_packets_with_libbpf(C.size_t(BatchFrames)))
+		total := int(C.libbpf_xsk__poll(l.libbpf, C.size_t(BatchFrames)))
+		// most likely BatchFrames(C.FRAME_BATCH_SIZE) packets in FQ waiting for proceed
 		log.Printf("libbpf fetch %d packets\n", total)
-		if total > 0 {
-			// most likely BatchFrames(16) packets in FQ waiting for proceed
-			for i := 0; i < total; i++ {
-				l.fetchOnePacketFromXSK()
-				if _, ok := <-l.next; !ok {
-					// next channel has been closed by Close, stop fetching packets from AF_XDP
-					return
-				}
-				C.rx_fwd()
+		for i := 0; i < total; i++ {
+			l.fetchOnePacketFromXSK()
+			if _, ok := <-l.next; !ok {
+				// next channel has been closed by Close, stop fetching packets from AF_XDP
+				return
 			}
-			l.flush(total)
 		}
 	}
 }
@@ -149,42 +149,22 @@ func (l *libbpfRunnerLinux) worker() {
 func (l *libbpfRunnerLinux) fetchOnePacketFromXSK() {
 	var bufptr *C.u_char
 	bptr := C.uintptr_t(uintptr(unsafe.Pointer(&bufptr)))
-	pktLen := int(C.read_packet_from_fq_torx_with_libbpf(bptr))
-
-	// Since we can't make sure there's no race condition between worker goroutine
-	// and a simple `go l.Drop()`, so we don't check the packet length here, and
-	// let packet-handler to drop this invalid packets. This way we can make sure
-	// the dropped packet is in the same lifecycle and race condition protection.
-
+	pktLen := int(C.libbpf_xsk__pkt_read(l.libbpf, bptr))
 	var data []byte
-	slice := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	slice.Data = uintptr(unsafe.Pointer(bufptr))
-	slice.Len = pktLen
-	slice.Cap = pktLen
-	l.incomming <- data
-}
 
-//
-func (l *libbpfRunnerLinux) flush(total int) {
-	handled := l.passed + l.injected + l.dropped
-	if total != handled {
+	// If we got invalid-length packet, we just pass a nil slice out
+	// packet handler should recognize this packet as invaid packet
+	// and drop it.
+	if pktLen > 0 {
+		slice := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+		slice.Data = uintptr(unsafe.Pointer(bufptr))
+		slice.Len = pktLen
+		slice.Cap = pktLen
 	}
 
-	C.flush_tx(C.int(l.passed + l.injected)) // flush_tx will trigger sendto to send packets in tx
-	C.flush_cq(C.int(l.passed + l.injected))
-
-	C.flush_rx(C.int(total)) // release buffers in rx
-	C.flush_fq(C.int(total)) // recycle buffers in fq
-
-	l.resetCounters()
+	l.incomming <- data
 }
 
 func (l *libbpfRunnerLinux) complete() {
 	l.next <- true
-}
-
-func (l *libbpfRunnerLinux) resetCounters() {
-	l.passed = 0
-	l.injected = 0
-	l.dropped = 0
 }

--- a/src/router/driver/libbpf/runner_linux.go
+++ b/src/router/driver/libbpf/runner_linux.go
@@ -133,9 +133,9 @@ func (l *libbpfRunnerLinux) worker() {
 	log.Println("Libbpf runner worker starting")
 	defer log.Println("Libbpf runner worker returned")
 	for atomic.LoadUint64(&l.flag) == process {
-		total := int(C.libbpf_xsk__poll(l.libbpf, C.size_t(BatchFrames)))
+		total := int(C.libbpf_xsk__pull_rx(l.libbpf, C.size_t(BatchFrames)))
 		// most likely BatchFrames(C.FRAME_BATCH_SIZE) packets in FQ waiting for proceed
-		log.Printf("libbpf fetch %d packets\n", total)
+		// log.Printf("libbpf fetch %d packets\n", total)
 		for i := 0; i < total; i++ {
 			l.fetchOnePacketFromXSK()
 			if _, ok := <-l.next; !ok {

--- a/src/router/driver/libbpf/xdp.h
+++ b/src/router/driver/libbpf/xdp.h
@@ -3,13 +3,21 @@
 #ifndef __GLASNOSTIC_LIBBPF_XDP_H__
 #define __GLASNOSTIC_LIBBPF_XDP_H__
 
+#include <poll.h>         // for pollfds
+
 #include "xsk.h"
+#include "mempool.h"
+
+struct membuf {
+	void *addr;
+	uint32_t len;
+};
 
 struct xsk_umem_ptr {
 	struct xsk_ring_prod fq; // fill queue
 	struct xsk_ring_cons cq; // completion queue
 	struct xsk_umem *umem;   // umem
-	void * buf;              // raw buffer
+	void *buf;               // should be the same as umem->umem_area
 };
 
 struct xsk_sock_ptr {
@@ -21,14 +29,15 @@ struct xsk_sock_ptr {
 	__u32 prog_id;
 };
 
-struct libbpf_pointer {
-	// struct pollfd pollfds;
-	struct xsk_sock_ptr* xsk;
-	__u32 rx_idx;
-	__u32 tx_idx;
-	__u32 fq_idx;
-	__u32 cq_idx;
-	int err;
+struct libbpf {
+	struct xsk_sock_ptr *xsk; //
+	struct mempool *pool;     // memory pool of availables
+	struct membuf *inqueue;   // membuf for reading packets
+	struct membuf *outqueue;  // membuf for sending packets
+	struct pollfd fds;        //
+	void **bufs;              //
+	int current;              // current idx of inqueue
+	int err;                  // error code
 };
 
 #endif /* __GLASNOSTIC_LIBBPF_XDP_H__ */

--- a/src/router/driver/libbpf/xdp.h
+++ b/src/router/driver/libbpf/xdp.h
@@ -9,7 +9,7 @@
 #include "mempool.h"
 
 struct membuf {
-	void *addr;
+	uint64_t addr;
 	uint32_t len;
 };
 
@@ -35,8 +35,9 @@ struct libbpf {
 	struct membuf *inqueue;   // membuf for reading packets
 	struct membuf *outqueue;  // membuf for sending packets
 	struct pollfd fds;        //
-	void **bufs;              //
+	uint64_t *bufs;           //
 	int current;              // current idx of inqueue
+	int current_cached;       // current cached size of inqueue
 	int err;                  // error code
 };
 


### PR DESCRIPTION
	- loose memory mapping, use an index/offset calculating
	  to get index and inverse lookup from data address
	- pre-configure memory stack
	- add mempool init in libbpf_xsk__init
	- add inqueue to hold packet we're handling from RX